### PR TITLE
Optimize sanitize method

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,6 @@
             "Cache::Memcached::Fast" : "0.23",
             "Digest::SHA" : "0",
             "POSIX::AtFork" : "0.02",
-            "URI::Escape::XS" : "0.09",
             "parent" : "0"
          }
       },

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ for fork-safe.
 This module allow to change sanitizing behavior through $Cache::Memcached::Fast::Safe::SANITIZE\_METHOD.
 Default sanitizer is
 
+    use bytes;
+    my %escapes = map { chr($_) => sprintf('%%%02X', $_) } (0x00..0x20, 0x7f..0xff);
     local $Cache::Memcached::Fast::Safe::SANITIZE_METHOD = sub {
         my $key = shift;
-        $key = uri_escape($key,"\x00-\x20\x7f-\xff");
+        $key =~ s/([\x00-\x20\x7f-\xff])/$escapes{$1}/ge;
         if ( length $key > 200 ) {
             $key = sha1_hex($key);
         }

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,6 @@
 requires 'Cache::Memcached::Fast', '0.23';
 requires 'Digest::SHA';
 requires 'POSIX::AtFork', '0.02';
-requires 'URI::Escape::XS', '0.09';
 requires 'parent';
 
 on test => sub {

--- a/lib/Cache/Memcached/Fast/Safe.pm
+++ b/lib/Cache/Memcached/Fast/Safe.pm
@@ -3,21 +3,26 @@ package Cache::Memcached::Fast::Safe;
 use strict;
 use warnings;
 use Cache::Memcached::Fast 0.19;
-use URI::Escape::XS qw/uri_escape/;
 use Digest::SHA qw/sha1_hex/;
 use parent qw/Cache::Memcached::Fast/;
 use POSIX::AtFork;
 use Scalar::Util qw/weaken/;
 
 our $VERSION = '0.05';
-our $SANITIZE_METHOD = sub {
-    my $key = shift;
-    $key = uri_escape($key,"\x00-\x20\x7f-\xff");
-    if ( length $key > 200 ) {
-        $key = sha1_hex($key);
+our $SANITIZE_METHOD = \&_sanitize_method;
+
+{
+    use bytes;
+    my %escapes = map { chr($_) => sprintf('%%%02X', $_) } (0x00..0x20, 0x7f..0xff);
+    sub _sanitize_method {
+        my $key = shift;
+        $key =~ s/([\x00-\x20\x7f-\xff])/$escapes{$1}/ge;
+        if ( length $key > 200 ) {
+            $key = sha1_hex($key);
+        }
+        $key;
     }
-    $key;
-};
+}
 
 sub new {
     my $class = shift;
@@ -179,9 +184,11 @@ callback can also return expires sec.
 This module allow to change sanitizing behavior through $Cache::Memcached::Fast::Safe::SANITIZE_METHOD.
 Default sanitizer is
 
+  use bytes;
+  my %escapes = map { chr($_) => sprintf('%%%02X', $_) } (0x00..0x20, 0x7f..0xff);
   local $Cache::Memcached::Fast::Safe::SANITIZE_METHOD = sub {
       my $key = shift;
-      $key = uri_escape($key,"\x00-\x20\x7f-\xff");
+      $key =~ s/([\x00-\x20\x7f-\xff])/$escapes{$1}/ge;
       if ( length $key > 200 ) {
           $key = sha1_hex($key);
       }


### PR DESCRIPTION
Use static regexp pattern instead of `URI::Escape::XS::uri_escape` to optimize sanitize method.

`URI::Escape::XS::uri_escape` is slow because of following reasons.

- doesn't use XS if a pattern is passed
    - https://github.com/dankogai/p5-uri-escape-xs/blob/17bb56e5dd429468da172a68995e5bae59d050f5/lib/URI/Escape/XS.pm#L34-L48
- compiles a regexp each time
    - https://github.com/dankogai/p5-uri-escape-xs/blob/17bb56e5dd429468da172a68995e5bae59d050f5/lib/URI/Escape/XS.pm#L46